### PR TITLE
Force OrleansVSTools to reference the same version of Newtonsoft.Json

### DIFF
--- a/src/OrleansVSTools/OrleansVSTools/OrleansVSTools.csproj
+++ b/src/OrleansVSTools/OrleansVSTools/OrleansVSTools.csproj
@@ -107,6 +107,10 @@
       <HintPath>..\packages\Microsoft.VisualStudio.Validation.14.1.111\lib\net45\Microsoft.VisualStudio.Validation.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
@@ -255,6 +259,7 @@
       <Link>Packages\Microsoft.Orleans.Templates.Interfaces.1.2.0.nupkg</Link>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
+    <None Include="app.config" />
     <None Include="OrleansVSTools.snk" />
     <None Include="packages.config" />
     <None Include="source.extension.vsixmanifest">

--- a/src/OrleansVSTools/OrleansVSTools/app.config
+++ b/src/OrleansVSTools/OrleansVSTools/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/OrleansVSTools/OrleansVSTools/packages.config
+++ b/src/OrleansVSTools/OrleansVSTools/packages.config
@@ -18,4 +18,5 @@
   <package id="Microsoft.VisualStudio.Threading" version="14.1.111" targetFramework="net451" />
   <package id="Microsoft.VisualStudio.Utilities" version="14.1.24720" targetFramework="net451" />
   <package id="Microsoft.VisualStudio.Validation" version="14.1.111" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
Force OrleansVSTools to reference the same version of Newtonsoft.Json as Orleans.
Otherwise the VSIX tooling will just use one from the probing paths (such as in `C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\PrivateAssemblies` which is 6.0.8 in my case) and override what's in the Output folder

The build is now passing locally in my machine with this change
